### PR TITLE
Mobile menu component

### DIFF
--- a/src/lib/components/organisms/Header.svelte
+++ b/src/lib/components/organisms/Header.svelte
@@ -6,6 +6,7 @@
 
   // custom js
   onMount(() => {
+    // toggle mobile menu & desktop menu
     const mediaQuery = window.matchMedia('(max-width: 65rem)')
     const hider = document.querySelector('.mobileHide')
 
@@ -18,8 +19,20 @@
     }
 
     updateMenu()
-
     mediaQuery.addEventListener('change', updateMenu)
+
+    // open & closing mobile menu
+    const closeMenuBtn = document.getElementById('mobileMenuClose')
+    const openMenuBtn = document.getElementById('mainMenuOpen')
+    const mobileMenu = document.getElementById('mobileMenu')
+
+    openMenuBtn.addEventListener('click', function () {
+      mobileMenu.style.top = '0'
+    })
+
+    closeMenuBtn.addEventListener('click', function () {
+      mobileMenu.style.top = '-100vh'
+    })
   })
 </script>
 
@@ -281,14 +294,14 @@
     }
 
     #mobileMenu {
-      display: none;
+      display: block;
       position: absolute;
       height: 100vh;
       width: 100vw;
       left: 0;
-      top: 00vh;
+      top: -100vh;
       background: var(--page-bg-color);
-      transition: 0.5s;
+      transition: 0.5s ease;
       z-index: 999;
     }
 

--- a/src/lib/components/organisms/Header.svelte
+++ b/src/lib/components/organisms/Header.svelte
@@ -11,8 +11,8 @@
       hider = document.querySelector('.mobileHide'),
       openMenuBtn = document.getElementById('mainMenuOpen'),
       closeMenuBtn = document.getElementById('mobileMenuClose')
-    // toggle mobile menu & desktop menu
 
+    // toggle mobile menu & desktop menu
     function updateMenu() {
       if (mediaQuery.matches) {
         hider.style.display = 'none'
@@ -290,12 +290,13 @@
 
   @media (max-width: 65rem) {
     .mobileHide {
-      display: block;
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
     }
     header {
       justify-content: 0;
     }
-
     :global(.mobileMenu) {
       display: none;
       position: absolute;
@@ -305,7 +306,6 @@
       top: -100vh;
       background: var(--page-bg-color);
       z-index: 999;
-      /* animation: shower 2sec forwards; */
     }
 
     .mobileMenu nav {
@@ -328,32 +328,6 @@
       background: transparent;
       cursor: pointer;
       order: 4;
-    }
-
-    :global(.showing) {
-      animation: shower 1s forwards;
-      display: block;
-    }
-    @keyframes shower {
-      0% {
-        transform: translateY(0vh);
-      }
-      100% {
-        transform: translateY(100vh);
-      }
-    }
-    :global(.hiding) {
-      animation: hider 1s forwards;
-    }
-    @keyframes hider {
-      0% {
-        display: block;
-        transform: translateY(100vh);
-      }
-      100% {
-        display: none;
-        transform: translateY(0vh);
-      }
     }
 
     #mainMenuOpen span,
@@ -412,12 +386,52 @@
       rotate: 90deg;
     }
 
+    .button-cart-container {
+      display: flex;
+      margin: 0 auto;
+    }
+
     div {
       display: flex;
       align-items: center;
       gap: 1rem;
       position: relative;
       top: 5px;
+    }
+    :global(.showing) {
+      top: 0vh;
+      display: block;
+    }
+    :global(.hiding) {
+      display: none;
+    }
+    @media (prefers-reduced-motion: no-preference) {
+      :global(.showing) {
+        animation: shower 1s forwards;
+        top: -100vh;
+        display: block;
+      }
+      @keyframes shower {
+        0% {
+          transform: translateY(0vh);
+        }
+        100% {
+          transform: translateY(100vh);
+        }
+      }
+      :global(.hiding) {
+        animation: hider 1s forwards;
+      }
+      @keyframes hider {
+        0% {
+          display: block;
+          transform: translateY(100vh);
+        }
+        100% {
+          display: none;
+          transform: translateY(0vh);
+        }
+      }
     }
   }
 </style>

--- a/src/lib/components/organisms/Header.svelte
+++ b/src/lib/components/organisms/Header.svelte
@@ -6,15 +6,20 @@
 
   // custom js
   onMount(() => {
+    const mediaQuery = window.matchMedia('(max-width: 65rem)'),
+      mobileMenu = document.querySelector('.mobileMenu'),
+      hider = document.querySelector('.mobileHide'),
+      openMenuBtn = document.getElementById('mainMenuOpen'),
+      closeMenuBtn = document.getElementById('mobileMenuClose')
     // toggle mobile menu & desktop menu
-    const mediaQuery = window.matchMedia('(max-width: 65rem)')
-    const hider = document.querySelector('.mobileHide')
 
     function updateMenu() {
       if (mediaQuery.matches) {
         hider.style.display = 'none'
+        openMenuBtn.style.display = 'block'
       } else {
         hider.style.display = 'block'
+        openMenuBtn.style.display = 'none'
       }
     }
 
@@ -22,17 +27,18 @@
     mediaQuery.addEventListener('change', updateMenu)
 
     // open & closing mobile menu
-    const closeMenuBtn = document.getElementById('mobileMenuClose')
-    const openMenuBtn = document.getElementById('mainMenuOpen')
-    const mobileMenu = document.getElementById('mobileMenu')
+    openMenuBtn.addEventListener('click', showing)
 
-    openMenuBtn.addEventListener('click', function () {
-      mobileMenu.style.top = '0'
-    })
+    function showing() {
+      mobileMenu.classList.remove('hiding')
+      mobileMenu.classList.add('showing')
+    }
 
-    closeMenuBtn.addEventListener('click', function () {
-      mobileMenu.style.top = '-100vh'
-    })
+    closeMenuBtn.addEventListener('click', hiding)
+    function hiding() {
+      mobileMenu.classList.remove('showing')
+      mobileMenu.classList.add('hiding')
+    }
   })
 </script>
 
@@ -48,15 +54,13 @@
     />
   </span>
   <img src={logo} height="70" width="70" alt="Wogo Logo" />
-  <button type="button" id="mainMenuOpen" tabindex="-1" aria-label="hamburger-button"
-    ><span></span></button
-  >
+  <button type="button" id="mainMenuOpen" aria-label="hamburger-button"><span></span></button>
   <nav>
     <ul class="mobileHide">
       {#each navigation.navigationLinksCollection.items as link}
         {#if link.title === 'More'}
           <li class="more-button">
-            <button class="">
+            <button>
               <span class="btn-icon">
                 More
                 <ArrowDown />
@@ -98,8 +102,7 @@
       {/each}
     </ul>
   </nav>
-  <section id="mobileMenu">
-    <button type="button" id="mobileMenuClose" aria-label="close-menu-button"><span></span></button>
+  <section class="mobileMenu">
     <nav>
       <ul>
         {#each navigation.navigationLinksCollection.items as link}
@@ -147,6 +150,7 @@
         {/each}
       </ul>
     </nav>
+    <button type="button" id="mobileMenuClose" aria-label="close-menu-button"><span></span></button>
   </section>
   <div class="button-cart-container">
     <CartIcon width="60px" height="60px" fill="var(--accent2-primary)" />
@@ -182,8 +186,7 @@
     z-index: 900;
   }
 
-  #mobileMenu,
-  #mainMenuOpen {
+  :global(.mobileMenu, #mainMenuOpen) {
     display: none;
   }
 
@@ -293,22 +296,22 @@
       justify-content: 0;
     }
 
-    #mobileMenu {
-      display: block;
+    :global(.mobileMenu) {
+      display: none;
       position: absolute;
       height: 100vh;
       width: 100vw;
       left: 0;
       top: -100vh;
       background: var(--page-bg-color);
-      transition: 0.5s ease;
       z-index: 999;
+      /* animation: shower 2sec forwards; */
     }
 
-    #mobileMenu nav {
+    .mobileMenu nav {
       margin-top: 20%;
     }
-    #mobileMenu nav li {
+    .mobileMenu nav li {
       display: flex;
       flex-direction: column;
       margin: 0 auto;
@@ -317,7 +320,7 @@
     }
 
     #mainMenuOpen {
-      display: block;
+      display: none;
       width: 40px;
       height: 30px;
       flex-grow: 0;
@@ -325,6 +328,32 @@
       background: transparent;
       cursor: pointer;
       order: 4;
+    }
+
+    :global(.showing) {
+      animation: shower 1s forwards;
+      display: block;
+    }
+    @keyframes shower {
+      0% {
+        transform: translateY(0vh);
+      }
+      100% {
+        transform: translateY(100vh);
+      }
+    }
+    :global(.hiding) {
+      animation: hider 1s forwards;
+    }
+    @keyframes hider {
+      0% {
+        display: block;
+        transform: translateY(100vh);
+      }
+      100% {
+        display: none;
+        transform: translateY(0vh);
+      }
     }
 
     #mainMenuOpen span,

--- a/src/lib/components/organisms/Header.svelte
+++ b/src/lib/components/organisms/Header.svelte
@@ -1,7 +1,26 @@
 <script>
+  import { onMount } from 'svelte'
   import { Link, CartIcon, ArrowDown, Button } from '$lib/index'
   import logo from '$lib/assets/logo.webp'
   export let navigation
+
+  // custom js
+  onMount(() => {
+    const mediaQuery = window.matchMedia('(max-width: 65rem)')
+    const hider = document.querySelector('.mobileHide')
+
+    function updateMenu() {
+      if (mediaQuery.matches) {
+        hider.style.display = 'none'
+      } else {
+        hider.style.display = 'block'
+      }
+    }
+
+    updateMenu()
+
+    mediaQuery.addEventListener('change', updateMenu)
+  })
 </script>
 
 <header>
@@ -20,7 +39,7 @@
     ><span></span></button
   >
   <nav>
-    <ul>
+    <ul class="mobileHide">
       {#each navigation.navigationLinksCollection.items as link}
         {#if link.title === 'More'}
           <li class="more-button">
@@ -66,6 +85,56 @@
       {/each}
     </ul>
   </nav>
+  <section id="mobileMenu">
+    <button type="button" id="mobileMenuClose" aria-label="close-menu-button"><span></span></button>
+    <nav>
+      <ul>
+        {#each navigation.navigationLinksCollection.items as link}
+          {#if link.title === 'More'}
+            <li class="more-button">
+              <button class="">
+                <span class="btn-icon">
+                  More
+                  <ArrowDown />
+                </span>
+              </button>
+              <ul class="more-dropdown">
+                {#each link.subLinksCollection.items as sublink}
+                  <li>
+                    <Link href={sublink.slug} title={sublink.title} aria-label={sublink.label} />
+                  </li>
+                {/each}
+              </ul>
+            </li>
+          {:else}
+            <li>
+              <Link
+                href={link.slug}
+                title={link.title}
+                arialabel={link.label}
+                color="var(--txt-primary-clr)"
+                filter="var(--filter-drop)"
+              />
+              {#if link.subLinksCollection.items.length > 0}
+                <ul class="sub-menu" aria-label="Submenu">
+                  {#each link.subLinksCollection.items as sublink}
+                    <li>
+                      <Link
+                        href={sublink.slug}
+                        title={sublink.title}
+                        aria-label={sublink.label}
+                        color="var(--txt-dark-clr)"
+                      />
+                    </li>
+                  {/each}
+                </ul>
+              {/if}
+            </li>
+          {/if}
+        {/each}
+      </ul>
+    </nav>
+  </section>
   <div class="button-cart-container">
     <CartIcon width="60px" height="60px" fill="var(--accent2-primary)" />
   </div>
@@ -100,6 +169,7 @@
     z-index: 900;
   }
 
+  #mobileMenu,
   #mainMenuOpen {
     display: none;
   }
@@ -202,15 +272,41 @@
     gap: 2rem;
   }
 
-  @media (max-width: 65em) {
+  @media (max-width: 65rem) {
+    .mobileHide {
+      display: block;
+    }
     header {
       justify-content: 0;
+    }
+
+    #mobileMenu {
+      display: none;
+      position: absolute;
+      height: 100vh;
+      width: 100vw;
+      left: 0;
+      top: 00vh;
+      background: var(--page-bg-color);
+      transition: 0.5s;
+      z-index: 999;
+    }
+
+    #mobileMenu nav {
+      margin-top: 20%;
+    }
+    #mobileMenu nav li {
+      display: flex;
+      flex-direction: column;
+      margin: 0 auto;
+      width: 6rem;
+      padding-top: 2rem;
     }
 
     #mainMenuOpen {
       display: block;
       width: 40px;
-      height: 3px;
+      height: 30px;
       flex-grow: 0;
       border: 0;
       background: transparent;
@@ -228,6 +324,7 @@
       height: 3px;
       background: var(--accent2-primary);
       border-radius: var(--radius-lg);
+      z-index: 998;
     }
     #mainMenuOpen span::before {
       margin-top: -12px;
@@ -241,47 +338,36 @@
       top: -8px;
     }
 
-    #mainMenuOpen + nav {
-      position: fixed;
-      top: 0;
-      left: -100%;
-      width: 100%;
-      height: 100%;
-      overflow: auto;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      opacity: 0;
-      background: var(--page-bg-color);
-      transition:
-        top 2s 0.5s,
-        opacity 0.5s;
-    }
-    #mainMenuOpen:focus + nav,
-    #mainMenuOpen + nav:focus-within {
-      left: 0;
-      opacity: 1;
-      transition:
-        top 0s,
-        opacity 0.5s;
-    }
-
-    #mainMenuOpen + nav li {
-      display: flex;
-      flex-direction: column;
-      font-size: var(--fs-xl);
-      padding: 1rem 0 1rem 0;
-    }
-
-    #mainMenuOpen + nav > ul:after {
-      content: '\2715';
-      color: var(--txt-primary-clr);
+    #mobileMenuClose {
       display: block;
       position: absolute;
-      top: 1.5rem;
-      right: 1.2rem;
-      font-size: 2.5rem;
+      width: 40px;
+      height: 35px;
+      flex-grow: 0;
+      border: 0;
+      background: transparent;
       cursor: pointer;
+      order: 4;
+      right: 2rem;
+      top: 2rem;
+    }
+    #mobileMenuClose span,
+    #mobileMenuClose span::after {
+      display: block;
+      position: absolute;
+      content: '';
+      width: 40px;
+      height: 3px;
+      background: var(--accent2-primary);
+      border-radius: var(--radius-lg);
+    }
+
+    #mobileMenuClose span {
+      rotate: 45deg;
+    }
+
+    #mobileMenuClose span::after {
+      rotate: 90deg;
     }
 
     div {

--- a/src/lib/components/organisms/Header.svelte
+++ b/src/lib/components/organisms/Header.svelte
@@ -315,8 +315,9 @@
       display: flex;
       flex-direction: column;
       margin: 0 auto;
-      width: 6rem;
+      width: 40vw;
       padding-top: 2rem;
+      font-size: 2rem;
     }
 
     #mainMenuOpen {
@@ -432,6 +433,11 @@
           transform: translateY(0vh);
         }
       }
+    }
+  }
+  @media (max-width: 35rem) {
+    .mobileMenu nav li {
+      font-size: 1.5rem;
     }
   }
 </style>


### PR DESCRIPTION
# Menu Component Update
In deze branch was/is het doel om de header te verbeteren, dit heb ik gedaan door meer na te denken over de principes zoals PE, Responsive en toegankelijkheid op de tablet en mobile versie. Op de desktop versie is weinig aangepast.

fixed #28 #15 

## Screenshot van oude versie
### Desktop
![image](https://github.com/user-attachments/assets/5b27dc9a-ee0a-4abf-8888-184ee696c2d8)

### Tablet
![image](https://github.com/user-attachments/assets/eebd0a54-dd4a-4377-b85f-3e6bfb0c71a1)

### Mobile
![image](https://github.com/user-attachments/assets/2b6cdb43-536d-4287-8b4d-a7e58dd1f9c6)

* Note: Na klikken op het menu (of je op een link klikt of niet) verdwijnt het menu weer
* Note: Om het menu te openen moet je precies op één van de lijntjes klikken om het te openen.

## Screenshot van resultaat
### Desktop 
![image](https://github.com/user-attachments/assets/4d75b2b2-f0c3-44de-89a9-a31e31020e2f)


### Tablet
![image](https://github.com/user-attachments/assets/3af6cfe3-80f1-4137-9d72-6b65f385b511)
![image](https://github.com/user-attachments/assets/968a3f1d-04e9-4a1b-8d35-1e9f5cf6d6f1)

 
### Mobile
![image](https://github.com/user-attachments/assets/c787f9af-85b0-458b-af5c-b1e3327b3adb)
![image](https://github.com/user-attachments/assets/e9e2b804-e0a0-448e-a2d6-96441b160451)


## Wat er is veranderd
### HTML
```HTML
  <section class="mobileMenu">
    <nav>
      <ul>
        {#each navigation.navigationLinksCollection.items as link}
          {#if link.title === 'More'}
            <li class="more-button">
              <button class="">
                <span class="btn-icon">
                  More
                  <ArrowDown />
                </span>
              </button>
              <ul class="more-dropdown">
                {#each link.subLinksCollection.items as sublink}
                  <li>
                    <Link href={sublink.slug} title={sublink.title} aria-label={sublink.label} />
                  </li>
                {/each}
              </ul>
            </li>
          {:else}
            <li>
              <Link
                href={link.slug}
                title={link.title}
                arialabel={link.label}
                color="var(--txt-primary-clr)"
                filter="var(--filter-drop)"
              />
              {#if link.subLinksCollection.items.length > 0}
                <ul class="sub-menu" aria-label="Submenu">
                  {#each link.subLinksCollection.items as sublink}
                    <li>
                      <Link
                        href={sublink.slug}
                        title={sublink.title}
                        aria-label={sublink.label}
                        color="var(--txt-dark-clr)"
                      />
                    </li>
                  {/each}
                </ul>
              {/if}
            </li>
          {/if}
        {/each}
      </ul>
    </nav>
    <button type="button" id="mobileMenuClose" aria-label="close-menu-button"><span></span></button>
  </section>
```
hier heb ik een extra menu gemaakt, dit had ik graag willen doen in een ander component om DRY toe te passen maar omdat het de pagina sloopte heb ik het voor nu niet gedaan.
### CSS
```CSS

  @media (max-width: 65rem) {
    .mobileHide {
      display: flex;
      flex-direction: row;
      flex-wrap: wrap;
    }
    header {
      justify-content: 0;
    }
    :global(.mobileMenu) {
      display: none;
      position: absolute;
      height: 100vh;
      width: 100vw;
      left: 0;
      top: -100vh;
      background: var(--page-bg-color);
      z-index: 999;
    }

    .mobileMenu nav {
      margin-top: 20%;
    }
    .mobileMenu nav li {
      display: flex;
      flex-direction: column;
      margin: 0 auto;
      width: 40vw;
      padding-top: 2rem;
      font-size: 2rem;
    }

    #mainMenuOpen {
      display: none;
      width: 40px;
      height: 30px;
      flex-grow: 0;
      border: 0;
      background: transparent;
      cursor: pointer;
      order: 4;
    }

    #mainMenuOpen span,
    #mainMenuOpen span::before,
    #mainMenuOpen span::after {
      display: block;
      position: absolute;
      content: '';
      width: 40px;
      height: 3px;
      background: var(--accent2-primary);
      border-radius: var(--radius-lg);
      z-index: 998;
    }
    #mainMenuOpen span::before {
      margin-top: -12px;
    }

    #mainMenuOpen span::after {
      margin-top: 12px;
    }

    #mainMenuOpen::before {
      top: -8px;
    }

    #mobileMenuClose {
      display: block;
      position: absolute;
      width: 40px;
      height: 35px;
      flex-grow: 0;
      border: 0;
      background: transparent;
      cursor: pointer;
      order: 4;
      right: 2rem;
      top: 2rem;
    }
    #mobileMenuClose span,
    #mobileMenuClose span::after {
      display: block;
      position: absolute;
      content: '';
      width: 40px;
      height: 3px;
      background: var(--accent2-primary);
      border-radius: var(--radius-lg);
    }

    #mobileMenuClose span {
      rotate: 45deg;
    }

    #mobileMenuClose span::after {
      rotate: 90deg;
    }

    .button-cart-container {
      display: flex;
      margin: 0 auto;
    }

    div {
      display: flex;
      align-items: center;
      gap: 1rem;
      position: relative;
      top: 5px;
    }
    :global(.showing) {
      top: 0vh;
      display: block;
    }
    :global(.hiding) {
      display: none;
    }
    @media (prefers-reduced-motion: no-preference) {
      :global(.showing) {
        animation: shower 1s forwards;
        top: -100vh;
        display: block;
      }
      @keyframes shower {
        0% {
          transform: translateY(0vh);
        }
        100% {
          transform: translateY(100vh);
        }
      }
      :global(.hiding) {
        animation: hider 1s forwards;
      }
      @keyframes hider {
        0% {
          display: block;
          transform: translateY(100vh);
        }
        100% {
          display: none;
          transform: translateY(0vh);
        }
      }
    }
  }
  @media (max-width: 35rem) {
    .mobileMenu nav li {
      font-size: 1.5rem;
    }
  }
```
Het grootste deel aan de toegevoegde code is in het mobile/tablet media query, ook heb ik een animatie toegevoegd als de gebruiker animaties heeft aanstaan.
### JS
```JS
  import { onMount } from 'svelte'
  import { Link, CartIcon, ArrowDown, Button } from '$lib/index'
  import logo from '$lib/assets/logo.webp'
  export let navigation

  // custom js
  onMount(() => {
    const mediaQuery = window.matchMedia('(max-width: 65rem)'),
      mobileMenu = document.querySelector('.mobileMenu'),
      hider = document.querySelector('.mobileHide'),
      openMenuBtn = document.getElementById('mainMenuOpen'),
      closeMenuBtn = document.getElementById('mobileMenuClose')

    // toggle mobile menu & desktop menu
    function updateMenu() {
      if (mediaQuery.matches) {
        hider.style.display = 'none'
        openMenuBtn.style.display = 'block'
      } else {
        hider.style.display = 'block'
        openMenuBtn.style.display = 'none'
      }
    }

    updateMenu()
    mediaQuery.addEventListener('change', updateMenu)

    // open & closing mobile menu
    openMenuBtn.addEventListener('click', showing)

    function showing() {
      mobileMenu.classList.remove('hiding')
      mobileMenu.classList.add('showing')
    }

    closeMenuBtn.addEventListener('click', hiding)
    function hiding() {
      mobileMenu.classList.remove('showing')
      mobileMenu.classList.add('hiding')
    }
  })
```
In de js heb ik custom js gebruikt door de onMount functie, de js is bedoelt voor de animatie activering/menu verschijnsel en het menu aan te passen met het formaat van het scherm.

### Locatie van aangepaste files/url's
- src/lib/components/organisms/header.svelte

### Test rapport
- [x] Usertest
- [x] Lighthouse
- [x] Tab 